### PR TITLE
Remove image assets and rely on text branding

### DIFF
--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loadComponent = (id, file) => {
+    fetch(file)
+      .then(response => response.text())
+      .then(html => {
+        const container = document.getElementById(id);
+        if (container) {
+          container.innerHTML = html;
+        }
+      });
+  };
+
+  loadComponent('header', 'partials/header.html');
+  loadComponent('footer', 'partials/footer.html');
+});

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,140 @@
+:root {
+  --color-bg: #f5f7fa;
+  --color-fg: #333333;
+  --color-muted: #666666;
+  --color-primary: #2E8B57;
+  --color-accent: #FFD700;
+  --font-body: 'Roboto', sans-serif;
+  --font-heading: 'Montserrat', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: var(--font-body);
+}
+
+
+.wrap {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 24px 16px 64px;
+}
+
+h1 {
+  font-family: var(--font-heading);
+  font-size: 28px;
+  margin: 8px 0 6px;
+  text-align: center;
+}
+
+.sub {
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 14px;
+  margin-bottom: 18px;
+}
+
+.card {
+  border-radius: 14px;
+  padding: 18px 16px;
+  margin: 12px 0;
+  background: #ffffff;
+  border: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.buy {
+  background: #123822;
+  color: #00ff88;
+}
+
+.hold {
+  background: #3a3515;
+  color: var(--color-accent);
+}
+
+.sell {
+  background: #3a1515;
+  color: #ff5a5a;
+}
+
+.break {
+  background: #1d2430;
+  color: #cbd5e1;
+}
+
+.asset {
+  font-size: 13px;
+  color: var(--color-muted);
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+
+.signal {
+  font-weight: 800;
+  font-size: 28px;
+}
+
+.meta {
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.since {
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+footer {
+  margin-top: 28px;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+header {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+}
+
+.logo {
+  font-family: var(--font-heading);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 16px;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+@media (max-width: 600px) {
+  .nav {
+    flex-direction: column;
+    gap: 8px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,60 +1,42 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Tankrich Signals</title>
-<style>
-:root {
-  --bg:#0f1115; --fg:#eaeaea; --muted:#9aa0a6;
-  --buy:#123822; --hold:#3a3515; --sell:#3a1515; --break:#1d2430;
-  --buyText:#00ff88; --holdText:#ffd700; --sellText:#ff5a5a; --breakText:#cbd5e1;
-  --card:#151922; --ring:#2a2f3a;
-}
-*{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Inter,Roboto,Helvetica,Arial,sans-serif}
-.wrap{max-width:860px;margin:0 auto;padding:24px 16px 64px}
-h1{font-size:28px;margin:8px 0 6px;text-align:center}
-.sub{text-align:center;color:var(--muted);font-size:14px;margin-bottom:18px}
-.card{border-radius:14px;padding:18px 16px;margin:12px 0;background:var(--card);border:1px solid var(--ring);display:flex;flex-direction:column;gap:6px}
-.asset{font-size:13px;color:var(--muted);letter-spacing:.3px;text-transform:uppercase}
-.signal{font-weight:800;font-size:28px}
-.meta{font-size:13px;color:var(--muted)}
-.since{font-size:14px;margin-top:4px}
-.buy{background:var(--buy);color:var(--buyText)}
-.hold{background:var(--hold);color:var(--holdText)}
-.sell{background:var(--sell);color:var(--sellText)}
-.break{background:var(--break);color:var(--breakText)}
-footer{margin-top:28px;text-align:center;color:var(--muted);font-size:12px}
-</style>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Tankrich Signals</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
+  <div id="header"></div>
   <div class="wrap">
     <h1><strong>TANKRICH SIGNALS</strong></h1>
     <div class="sub">Last updated: Wed, 13 Aug 2025 11:27 UTC</div>
-    
-        <div class="card hold">
-          <div class="asset">BTC</div>
-          <div class="signal">🟡 STAY PUT</div>
-          <div class="meta">BTCUSD • Weekly</div>
-          <div class="since">Entry date: <strong>2025-05-09</strong></div>
-        </div>
-        
-        <div class="card hold">
-          <div class="asset">Gold</div>
-          <div class="signal">🟡 STAY PUT</div>
-          <div class="meta">GLD • Monthly</div>
-          <div class="since">Entry date: <strong>2023-03-04</strong></div>
-        </div>
-        
-        <div class="card hold">
-          <div class="asset">Silver</div>
-          <div class="signal">🟡 STAY PUT</div>
-          <div class="meta">SLV • Monthly</div>
-          <div class="since">Entry date: <strong>2023-08-01</strong></div>
-        </div>
-        
+
+    <div class="card hold">
+      <div class="asset">BTC</div>
+      <div class="signal">🟡 STAY PUT</div>
+      <div class="meta">BTCUSD • Weekly</div>
+      <div class="since">Entry date: <strong>2025-05-09</strong></div>
+    </div>
+
+    <div class="card hold">
+      <div class="asset">Gold</div>
+      <div class="signal">🟡 STAY PUT</div>
+      <div class="meta">GLD • Monthly</div>
+      <div class="since">Entry date: <strong>2023-03-04</strong></div>
+    </div>
+
+    <div class="card hold">
+      <div class="asset">Silver</div>
+      <div class="signal">🟡 STAY PUT</div>
+      <div class="meta">SLV • Monthly</div>
+      <div class="since">Entry date: <strong>2023-08-01</strong></div>
+    </div>
+
     <footer>Signals auto-generated every Monday 09:00 UTC • Data: Kraken/Coinbase (BTC), Yahoo Finance ETFs (GLD/SLV)</footer>
   </div>
+  <div id="footer"></div>
+  <script src="assets/scripts.js"></script>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>© 2025 Tankrich Signals. All rights reserved.</p>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,8 @@
+<nav class="nav">
+  <div class="logo">Tankrich Signals</div>
+  <ul class="nav-links">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Signals</a></li>
+    <li><a href="#">About</a></li>
+  </ul>
+</nav>


### PR DESCRIPTION
## Summary
- drop `assets/images` and references to favicon and hero
- replace header logo with text-based branding and update styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12bc1984c832f855672e87df76175