### PR TITLE
Restore themed signals UI and re-enable automatic theme recovery

### DIFF
--- a/.github/workflows/theme-guard.yml
+++ b/.github/workflows/theme-guard.yml
@@ -1,0 +1,44 @@
+name: Theme Guard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '15 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  restore-theme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Restore themed layout when needed
+        run: python scripts/theme_guard.py
+
+      - name: Commit theme fix if changed
+        if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
+        run: |
+          if git diff --quiet; then
+            echo "No theme recovery needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.html
+          git commit -m "Auto-restore themed layout after signal deploy"
+          git push

--- a/index.html
+++ b/index.html
@@ -4,57 +4,134 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Tankrich Signals</title>
+<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
 <style>
-:root {
-  --bg:#0f1115; --fg:#eaeaea; --muted:#9aa0a6;
-  --buy:#123822; --hold:#3a3515; --sell:#3a1515; --break:#1d2430;
-  --buyText:#00ff88; --holdText:#ffd700; --sellText:#ff5a5a; --breakText:#cbd5e1;
-  --card:#151922; --ring:#2a2f3a;
-}
-*{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Inter,Roboto,Helvetica,Arial,sans-serif}
-.wrap{max-width:860px;margin:0 auto;padding:24px 16px 64px}
-h1{font-size:28px;margin:8px 0 6px;text-align:center}
-.sub{text-align:center;color:var(--muted);font-size:14px;margin-bottom:18px}
-.card{border-radius:14px;padding:18px 16px;margin:12px 0;background:var(--card);border:1px solid var(--ring);display:flex;flex-direction:column;gap:6px}
-.asset{font-size:13px;color:var(--muted);letter-spacing:.3px;text-transform:uppercase}
-.signal{font-weight:800;font-size:28px}
-.meta{font-size:13px;color:var(--muted)}
-.since{font-size:14px;margin-top:4px}
-.buy{background:var(--buy);color:var(--buyText)}
-.hold{background:var(--hold);color:var(--holdText)}
-.sell{background:var(--sell);color:var(--sellText)}
-.break{background:var(--break);color:var(--breakText)}
-footer{margin-top:28px;text-align:center;color:var(--muted);font-size:12px}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root { --gold: #f5c842; --gold2: #e8a020; --green: #00ff88; --red: #ff4466; --slate: #8899bb; }
+html, body { width: 100%; height: 100%; overflow-x: hidden; background: #000; color: #fff; font-family: 'Space Grotesk', sans-serif; }
+canvas#space { position: fixed; inset: 0; z-index: 0; pointer-events: none; }
+.wrap { position: relative; z-index: 10; max-width: 900px; margin: 0 auto; padding: 0 24px 100px; }
+.hero { text-align: center; padding: 80px 0 56px; }
+.eyebrow { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.35em; text-transform: uppercase; color: var(--green); margin-bottom: 20px; display: flex; align-items: center; justify-content: center; gap: 12px; }
+.eyebrow::before, .eyebrow::after { content: ''; width: 40px; height: 1px; background: var(--green); opacity: 0.5; }
+.eyebrow-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); animation: blink 2s ease-in-out infinite; display: inline-block; }
+@keyframes blink { 0%,100%{opacity:1;box-shadow:0 0 6px var(--green)} 50%{opacity:0.3;box-shadow:none} }
+h1 { font-family: 'Bebas Neue', sans-serif; font-size: clamp(56px, 10vw, 110px); letter-spacing: 0.06em; line-height: 0.9; background: linear-gradient(180deg, #ffffff 30%, rgba(255,255,255,0.4)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; margin-bottom: 16px; }
+h1 span { background: linear-gradient(135deg, var(--green) 0%, #00ccff 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+.timestamp { font-family: 'Space Mono', monospace; font-size: 11px; color: rgba(255,255,255,0.35); letter-spacing: 0.1em; margin-top: 12px; }
+.timestamp em { color: rgba(255,255,255,0.6); font-style: normal; }
+.solar-divider { position: relative; height: 180px; margin: 0 auto 60px; display: flex; align-items: center; justify-content: center; }
+.orbit-container { position: relative; width: 160px; height: 160px; flex-shrink: 0; }
+.sun { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 28px; height: 28px; border-radius: 50%; background: radial-gradient(circle at 40% 40%, #fffacc, #f5c842 40%, #e8820a); box-shadow: 0 0 20px 8px rgba(245,200,66,0.5), 0 0 60px 20px rgba(245,200,66,0.2); animation: sunPulse 4s ease-in-out infinite; z-index: 5; }
+@keyframes sunPulse { 0%,100%{box-shadow:0 0 20px 8px rgba(245,200,66,0.5),0 0 60px 20px rgba(245,200,66,0.2)} 50%{box-shadow:0 0 30px 14px rgba(245,200,66,0.7),0 0 80px 30px rgba(245,200,66,0.3)} }
+.orbit { position: absolute; left: 50%; top: 50%; border-radius: 50%; border: 1px solid rgba(255,255,255,0.08); transform-origin: center center; }
+.orbit-1 { width: 64px; height: 64px; margin-left: -32px; margin-top: -32px; animation: spin 5s linear infinite; }
+.orbit-2 { width: 100px; height: 100px; margin-left: -50px; margin-top: -50px; animation: spin 10s linear infinite; }
+.orbit-3 { width: 140px; height: 140px; margin-left: -70px; margin-top: -70px; animation: spin 18s linear infinite reverse; }
+@keyframes spin { from{transform:rotate(0deg)} to{transform:rotate(360deg)} }
+.planet { position: absolute; border-radius: 50%; }
+.orbit-1 .planet { width: 9px; height: 9px; top: 50%; left: 0; margin-top: -4.5px; background: radial-gradient(circle at 35% 35%, #aaddff, #4488cc); box-shadow: 0 0 8px #66aaff; }
+.orbit-2 .planet { width: 12px; height: 12px; top: 50%; right: 0; margin-top: -6px; background: radial-gradient(circle at 35% 35%, #ffddaa, #cc8833); box-shadow: 0 0 10px rgba(255,180,80,0.8); }
+.orbit-3 .planet { width: 10px; height: 10px; top: 0; left: 50%; margin-left: -5px; background: radial-gradient(circle at 35% 35%, #ccffdd, #44cc88); box-shadow: 0 0 10px rgba(0,255,136,0.7); }
+.div-line { flex: 1; height: 1px; background: linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent); max-width: 300px; }
+.cards { display: flex; flex-direction: column; gap: 2px; }
+.signals-explainer { margin: 0 0 30px; padding: 22px 24px; border: 1px solid rgba(0,255,136,0.25); background: linear-gradient(135deg, rgba(0,255,136,0.08), rgba(0,204,255,0.04)); border-radius: 12px; }
+.signals-explainer h2 { font-family: 'Bebas Neue', sans-serif; font-size: 34px; letter-spacing: 0.04em; margin-bottom: 10px; color: #ffffff; }
+.signals-explainer p { color: rgba(255,255,255,0.78); line-height: 1.65; margin-bottom: 14px; font-size: 15px; }
+.signals-explainer a { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--green); border: 1px solid rgba(0,255,136,0.5); padding: 8px 12px; border-radius: 6px; }
+.card { position: relative; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.07); border-left: none; padding: 28px 36px; display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 20px; overflow: hidden; }
+.card::before { content:''; position:absolute; left:0; top:0; bottom:0; width:3px; }
+.card.hold::before { background: linear-gradient(180deg, var(--gold), var(--gold2)); } .card.buy::before { background: linear-gradient(180deg, var(--green), #00cc66); } .card.sell::before { background: linear-gradient(180deg, var(--red), #cc2244); } .card.break::before { background: linear-gradient(180deg, var(--slate), #556688); }
+.card-orbit { position: absolute; right: -60px; top: 50%; transform: translateY(-50%); width: 140px; height: 140px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.04); pointer-events: none; }
+.card-orbit::after { content:''; position:absolute; width: 8px; height: 8px; border-radius: 50%; top: 0; left: 50%; margin-left: -4px; margin-top: -4px; }
+.card.hold .card-orbit { animation: spin 12s linear infinite; } .card.hold .card-orbit::after { background: var(--gold); box-shadow: 0 0 8px var(--gold); }
+.card.buy .card-orbit { animation: spin 8s linear infinite; } .card.buy .card-orbit::after { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.card.sell .card-orbit { animation: spin 6s linear infinite reverse; } .card.sell .card-orbit::after { background: var(--red); box-shadow: 0 0 8px var(--red); }
+.card.break .card-orbit { animation: spin 20s linear infinite; } .card.break .card-orbit::after { background: var(--slate); box-shadow: 0 0 8px var(--slate); }
+.card-asset { font-family: 'Bebas Neue', sans-serif; font-size: 42px; letter-spacing: 0.05em; margin-bottom: 8px; }
+.card-signal { font-family: 'Space Mono', monospace; font-size: 12px; letter-spacing: 0.2em; text-transform: uppercase; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+.card.hold .card-signal { color: var(--gold); } .card.buy .card-signal { color: var(--green); } .card.sell .card-signal { color: var(--red); } .card.break .card-signal { color: var(--slate); }
+.signal-dot { width: 7px; height: 7px; border-radius: 50%; }
+.card-meta { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.meta-pill { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 0.15em; text-transform: uppercase; color: rgba(255,255,255,0.35); border: 1px solid rgba(255,255,255,0.1); padding: 3px 8px; border-radius: 4px; }
+.entry-date { font-family: 'Space Mono', monospace; font-size: 10px; color: rgba(255,255,255,0.3); letter-spacing: 0.05em; }
+.entry-date strong { color: rgba(255,255,255,0.55); font-weight: 400; }
+.card-glyph { font-family: 'Bebas Neue', sans-serif; font-size: 72px; opacity: 0.1; }
+footer { margin-top: 60px; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.07); display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+.footer-logo { font-family: 'Bebas Neue', sans-serif; font-size: 18px; letter-spacing: 0.15em; color: rgba(255,255,255,0.3); }
+.footer-text { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255,255,255,0.2); text-align: right; line-height: 1.8; }
 </style>
 </head>
 <body>
-  <div class="wrap">
-    <h1><strong>TANKRICH SIGNALS</strong></h1>
-    <div class="sub">Last updated: Mon, 09 Mar 2026 09:41 UTC</div>
-    
-        <div class="card break">
-          <div class="asset">BTC</div>
-          <div class="signal">⚪ HOLIDAY BREAK</div>
-          <div class="meta">BTCUSD • Weekly</div>
-          <div class="since">Entry date: <strong>2025-08-25</strong></div>
-        </div>
-        
-        <div class="card hold">
-          <div class="asset">Gold</div>
-          <div class="signal">🟡 STAY PUT</div>
-          <div class="meta">GLD • Monthly</div>
-          <div class="since">Entry date: <strong>2023-03-04</strong></div>
-        </div>
-        
-        <div class="card hold">
-          <div class="asset">Silver</div>
-          <div class="signal">🟡 STAY PUT</div>
-          <div class="meta">SLV • Monthly</div>
-          <div class="since">Entry date: <strong>2023-08-01</strong></div>
-        </div>
-        
-    <footer>Signals auto-generated every Monday 09:00 UTC • Data: Kraken/Coinbase (BTC), Yahoo Finance ETFs (GLD/SLV)</footer>
+<canvas id="space"></canvas>
+<div class="wrap">
+  <div class="hero">
+    <div class="eyebrow"><span class="eyebrow-dot"></span>Market Intelligence Active<span class="eyebrow-dot"></span></div>
+    <h1>TANK<span>RICH</span><br>SIGNALS</h1>
+    <div class="timestamp">↻ UPDATED <em>MON 09 MAR 2026 09:41 UTC</em></div>
   </div>
+  <div class="solar-divider">
+    <div class="div-line"></div>
+    <div class="orbit-container">
+      <div class="sun"></div><div class="orbit orbit-1"><div class="planet"></div></div><div class="orbit orbit-2"><div class="planet"></div></div><div class="orbit orbit-3"><div class="planet"></div></div>
+    </div>
+    <div class="div-line"></div>
+  </div>
+  <div class="cards">
+    <section class="signals-explainer">
+      <h2>New to Tankrich Signals?</h2>
+      <p>If you're wondering what each signal means and how to interpret these updates, start with the full methodology and explanation shared by Vivek Bothra.</p>
+      <a href="https://open.substack.com/pub/vivekbothra/p/tankrich-signals?" target="_blank" rel="noopener noreferrer">Read signal explanation ↗</a>
+    </section>
+    <div class="card break">
+      <div class="card-orbit"></div>
+      <div class="card-left">
+        <div class="card-asset">Bitcoin</div>
+        <div class="card-signal"><span class="signal-dot"></span>Holiday Break</div>
+        <div class="card-meta">
+          <span class="meta-pill">BTCUSD</span>
+          <span class="meta-pill">Weekly</span>
+          <span class="entry-date">Entry: <strong>2025-08-25</strong></span>
+        </div>
+      </div>
+      <div class="card-glyph">BRK</div>
+    </div>
+
+    <div class="card hold">
+      <div class="card-orbit"></div>
+      <div class="card-left">
+        <div class="card-asset">Gold</div>
+        <div class="card-signal"><span class="signal-dot"></span>Stay Put</div>
+        <div class="card-meta">
+          <span class="meta-pill">GLD</span>
+          <span class="meta-pill">Monthly</span>
+          <span class="entry-date">Entry: <strong>2023-03-04</strong></span>
+        </div>
+      </div>
+      <div class="card-glyph">HLD</div>
+    </div>
+
+    <div class="card hold">
+      <div class="card-orbit"></div>
+      <div class="card-left">
+        <div class="card-asset">Silver</div>
+        <div class="card-signal"><span class="signal-dot"></span>Stay Put</div>
+        <div class="card-meta">
+          <span class="meta-pill">SLV</span>
+          <span class="meta-pill">Monthly</span>
+          <span class="entry-date">Entry: <strong>2023-08-01</strong></span>
+        </div>
+      </div>
+      <div class="card-glyph">HLD</div>
+    </div>
+  </div>
+  <footer>
+    <div class="footer-logo">TANKRICH</div>
+    <div class="footer-text">Signals auto-generated every Monday 09:00 UTC<br>Data: Kraken/Coinbase (BTC) · Yahoo Finance ETFs (GLD/SLV)</div>
+  </footer>
+</div>
+<script>
+const canvas=document.getElementById('space'),ctx=canvas.getContext('2d');let W,H,stars=[],shooters=[];function resize(){W=canvas.width=window.innerWidth;H=canvas.height=window.innerHeight}resize();window.addEventListener('resize',()=>{resize();initStars()});function rand(a,b){return a+Math.random()*(b-a)}function initStars(){stars=[];const count=Math.floor(W*H/3500);for(let i=0;i<count;i++)stars.push({x:rand(0,W),y:rand(0,H),r:rand(.3,1.8),alpha:rand(.2,1),speed:rand(.0002,.001),phase:rand(0,Math.PI*2)})}initStars();class Shooter{constructor(){this.reset()}reset(){this.x=rand(0,W*.7);this.y=rand(0,H*.4);this.speed=rand(8,16);this.life=1;this.decay=rand(.012,.025);this.angle=rand(Math.PI/8,Math.PI/4);this.vx=Math.cos(this.angle)*this.speed;this.vy=Math.sin(this.angle)*this.speed}draw(){ctx.save();ctx.globalAlpha=.9*this.life;const grad=ctx.createLinearGradient(this.x,this.y,this.x-8*this.vx,this.y-8*this.vy);grad.addColorStop(0,'rgba(255,255,255,0.9)');grad.addColorStop(1,'rgba(255,255,255,0)');ctx.strokeStyle=grad;ctx.lineWidth=1.5;ctx.beginPath();ctx.moveTo(this.x,this.y);ctx.lineTo(this.x-8*this.vx,this.y-8*this.vy);ctx.stroke();ctx.restore()}update(){return this.x+=this.vx,this.y+=this.vy,this.life-=this.decay,this.life>0}}function drawNebulae(){[{x:.15*W,y:.25*H,r:220,c:'80,40,160'},{x:.82*W,y:.15*H,r:180,c:'0,80,160'},{x:.5*W,y:.8*H,r:250,c:'0,120,80'},{x:.9*W,y:.7*H,r:160,c:'140,60,20'}].forEach(n=>{const g=ctx.createRadialGradient(n.x,n.y,0,n.x,n.y,n.r);g.addColorStop(0,`rgba(${n.c},0.06)`);g.addColorStop(.5,`rgba(${n.c},0.02)`);g.addColorStop(1,'rgba(0,0,0,0)');ctx.beginPath();ctx.arc(n.x,n.y,n.r,0,2*Math.PI);ctx.fillStyle=g;ctx.fill()})}let lastShooter=0;function loop(ts){const t=.001*ts;ctx.clearRect(0,0,W,H);const bg=ctx.createRadialGradient(W/2,H/2,0,W/2,H/2,Math.max(W,H));bg.addColorStop(0,'#0a0e18');bg.addColorStop(1,'#000004');ctx.fillStyle=bg;ctx.fillRect(0,0,W,H);drawNebulae();stars.forEach(s=>{const a=s.alpha*(.6+.4*Math.sin(1e3*t*s.speed+s.phase));ctx.beginPath();ctx.arc(s.x,s.y,s.r,0,2*Math.PI);ctx.fillStyle=`rgba(255,255,255,${a})`;ctx.fill()});if(ts-lastShooter>rand(1800,4000)){shooters.push(new Shooter);lastShooter=ts}shooters=shooters.filter(s=>(s.draw(),s.update()));requestAnimationFrame(loop)}requestAnimationFrame(loop);
+</script>
 </body>
 </html>

--- a/scripts/theme_guard.py
+++ b/scripts/theme_guard.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Restore the themed Tankrich layout if automation replaced it with the basic layout."""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+INDEX_PATH = Path("index.html")
+
+ASSET_LABELS = {
+    "BTC": "Bitcoin",
+    "Gold": "Gold",
+    "Silver": "Silver",
+    "GLD": "Gold",
+    "SLV": "Silver",
+}
+
+SIGNAL_MAP = {
+    "HOLIDAY BREAK": ("break", "Holiday Break", "BRK"),
+    "STAY PUT": ("hold", "Stay Put", "HLD"),
+    "ACCUMULATE": ("buy", "Accumulate", "BUY"),
+    "REDUCE": ("sell", "Reduce", "SEL"),
+}
+
+
+def _extract_basic_layout_data(content: str) -> tuple[str, list[dict[str, str]]] | None:
+    updated_match = re.search(r"<div class=\"sub\">Last updated:\s*(.*?)</div>", content, re.S)
+    if not updated_match:
+        return None
+
+    card_pattern = re.compile(
+        r"<div class=\"card\s+(buy|hold|sell|break)\">\s*"
+        r"<div class=\"asset\">(.*?)</div>\s*"
+        r"<div class=\"signal\">.*?\s*([A-Z ]+)</div>\s*"
+        r"<div class=\"meta\">(.*?)\s*•\s*(.*?)</div>\s*"
+        r"<div class=\"since\">Entry date:\s*<strong>(.*?)</strong></div>",
+        re.S,
+    )
+
+    cards = []
+    for klass, asset, signal_key, ticker, timeframe, entry in card_pattern.findall(content):
+        signal_key = signal_key.strip()
+        mapped = SIGNAL_MAP.get(signal_key, (klass, signal_key.title(), klass.upper()[:3]))
+        cards.append(
+            {
+                "klass": mapped[0],
+                "asset": asset.strip(),
+                "signal": mapped[1],
+                "glyph": mapped[2],
+                "ticker": ticker.strip(),
+                "timeframe": timeframe.strip(),
+                "entry": entry.strip(),
+            }
+        )
+
+    if not cards:
+        return None
+
+    return updated_match.group(1).strip(), cards
+
+
+def _build_cards(cards: list[dict[str, str]]) -> str:
+    blocks = []
+    for c in cards:
+        asset_label = ASSET_LABELS.get(c["asset"], c["asset"])
+        blocks.append(
+            f'''    <div class="card {html.escape(c["klass"]) }">
+      <div class="card-orbit"></div>
+      <div class="card-left">
+        <div class="card-asset">{html.escape(asset_label)}</div>
+        <div class="card-signal"><span class="signal-dot"></span>{html.escape(c["signal"])}</div>
+        <div class="card-meta">
+          <span class="meta-pill">{html.escape(c["ticker"])}</span>
+          <span class="meta-pill">{html.escape(c["timeframe"])}</span>
+          <span class="entry-date">Entry: <strong>{html.escape(c["entry"])}</strong></span>
+        </div>
+      </div>
+      <div class="card-glyph">{html.escape(c["glyph"])}</div>
+    </div>'''
+        )
+    return "\n\n".join(blocks)
+
+
+def _build_themed_page(updated: str, cards: list[dict[str, str]]) -> str:
+    timestamp = updated.upper().replace(",", "")
+    cards_html = _build_cards(cards)
+    return f'''<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Tankrich Signals</title>
+<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+<style>
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+:root {{ --gold: #f5c842; --gold2: #e8a020; --green: #00ff88; --red: #ff4466; --slate: #8899bb; }}
+html, body {{ width: 100%; height: 100%; overflow-x: hidden; background: #000; color: #fff; font-family: 'Space Grotesk', sans-serif; }}
+canvas#space {{ position: fixed; inset: 0; z-index: 0; pointer-events: none; }}
+.wrap {{ position: relative; z-index: 10; max-width: 900px; margin: 0 auto; padding: 0 24px 100px; }}
+.hero {{ text-align: center; padding: 80px 0 56px; }}
+.eyebrow {{ font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.35em; text-transform: uppercase; color: var(--green); margin-bottom: 20px; display: flex; align-items: center; justify-content: center; gap: 12px; }}
+.eyebrow::before, .eyebrow::after {{ content: ''; width: 40px; height: 1px; background: var(--green); opacity: 0.5; }}
+.eyebrow-dot {{ width: 6px; height: 6px; border-radius: 50%; background: var(--green); animation: blink 2s ease-in-out infinite; display: inline-block; }}
+@keyframes blink {{ 0%,100%{{opacity:1;box-shadow:0 0 6px var(--green)}} 50%{{opacity:0.3;box-shadow:none}} }}
+h1 {{ font-family: 'Bebas Neue', sans-serif; font-size: clamp(56px, 10vw, 110px); letter-spacing: 0.06em; line-height: 0.9; background: linear-gradient(180deg, #ffffff 30%, rgba(255,255,255,0.4)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; margin-bottom: 16px; }}
+h1 span {{ background: linear-gradient(135deg, var(--green) 0%, #00ccff 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }}
+.timestamp {{ font-family: 'Space Mono', monospace; font-size: 11px; color: rgba(255,255,255,0.35); letter-spacing: 0.1em; margin-top: 12px; }}
+.timestamp em {{ color: rgba(255,255,255,0.6); font-style: normal; }}
+.solar-divider {{ position: relative; height: 180px; margin: 0 auto 60px; display: flex; align-items: center; justify-content: center; }}
+.orbit-container {{ position: relative; width: 160px; height: 160px; flex-shrink: 0; }}
+.sun {{ position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 28px; height: 28px; border-radius: 50%; background: radial-gradient(circle at 40% 40%, #fffacc, #f5c842 40%, #e8820a); box-shadow: 0 0 20px 8px rgba(245,200,66,0.5), 0 0 60px 20px rgba(245,200,66,0.2); animation: sunPulse 4s ease-in-out infinite; z-index: 5; }}
+@keyframes sunPulse {{ 0%,100%{{box-shadow:0 0 20px 8px rgba(245,200,66,0.5),0 0 60px 20px rgba(245,200,66,0.2)}} 50%{{box-shadow:0 0 30px 14px rgba(245,200,66,0.7),0 0 80px 30px rgba(245,200,66,0.3)}} }}
+.orbit {{ position: absolute; left: 50%; top: 50%; border-radius: 50%; border: 1px solid rgba(255,255,255,0.08); transform-origin: center center; }}
+.orbit-1 {{ width: 64px; height: 64px; margin-left: -32px; margin-top: -32px; animation: spin 5s linear infinite; }}
+.orbit-2 {{ width: 100px; height: 100px; margin-left: -50px; margin-top: -50px; animation: spin 10s linear infinite; }}
+.orbit-3 {{ width: 140px; height: 140px; margin-left: -70px; margin-top: -70px; animation: spin 18s linear infinite reverse; }}
+@keyframes spin {{ from{{transform:rotate(0deg)}} to{{transform:rotate(360deg)}} }}
+.planet {{ position: absolute; border-radius: 50%; }}
+.orbit-1 .planet {{ width: 9px; height: 9px; top: 50%; left: 0; margin-top: -4.5px; background: radial-gradient(circle at 35% 35%, #aaddff, #4488cc); box-shadow: 0 0 8px #66aaff; }}
+.orbit-2 .planet {{ width: 12px; height: 12px; top: 50%; right: 0; margin-top: -6px; background: radial-gradient(circle at 35% 35%, #ffddaa, #cc8833); box-shadow: 0 0 10px rgba(255,180,80,0.8); }}
+.orbit-3 .planet {{ width: 10px; height: 10px; top: 0; left: 50%; margin-left: -5px; background: radial-gradient(circle at 35% 35%, #ccffdd, #44cc88); box-shadow: 0 0 10px rgba(0,255,136,0.7); }}
+.div-line {{ flex: 1; height: 1px; background: linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent); max-width: 300px; }}
+.cards {{ display: flex; flex-direction: column; gap: 2px; }}
+.signals-explainer {{ margin: 0 0 30px; padding: 22px 24px; border: 1px solid rgba(0,255,136,0.25); background: linear-gradient(135deg, rgba(0,255,136,0.08), rgba(0,204,255,0.04)); border-radius: 12px; }}
+.signals-explainer h2 {{ font-family: 'Bebas Neue', sans-serif; font-size: 34px; letter-spacing: 0.04em; margin-bottom: 10px; color: #ffffff; }}
+.signals-explainer p {{ color: rgba(255,255,255,0.78); line-height: 1.65; margin-bottom: 14px; font-size: 15px; }}
+.signals-explainer a {{ display: inline-flex; align-items: center; gap: 8px; text-decoration: none; font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--green); border: 1px solid rgba(0,255,136,0.5); padding: 8px 12px; border-radius: 6px; }}
+.card {{ position: relative; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.07); border-left: none; padding: 28px 36px; display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 20px; overflow: hidden; }}
+.card::before {{ content:''; position:absolute; left:0; top:0; bottom:0; width:3px; }}
+.card.hold::before {{ background: linear-gradient(180deg, var(--gold), var(--gold2)); }} .card.buy::before {{ background: linear-gradient(180deg, var(--green), #00cc66); }} .card.sell::before {{ background: linear-gradient(180deg, var(--red), #cc2244); }} .card.break::before {{ background: linear-gradient(180deg, var(--slate), #556688); }}
+.card-orbit {{ position: absolute; right: -60px; top: 50%; transform: translateY(-50%); width: 140px; height: 140px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.04); pointer-events: none; }}
+.card-orbit::after {{ content:''; position:absolute; width: 8px; height: 8px; border-radius: 50%; top: 0; left: 50%; margin-left: -4px; margin-top: -4px; }}
+.card.hold .card-orbit {{ animation: spin 12s linear infinite; }} .card.hold .card-orbit::after {{ background: var(--gold); box-shadow: 0 0 8px var(--gold); }}
+.card.buy .card-orbit {{ animation: spin 8s linear infinite; }} .card.buy .card-orbit::after {{ background: var(--green); box-shadow: 0 0 8px var(--green); }}
+.card.sell .card-orbit {{ animation: spin 6s linear infinite reverse; }} .card.sell .card-orbit::after {{ background: var(--red); box-shadow: 0 0 8px var(--red); }}
+.card.break .card-orbit {{ animation: spin 20s linear infinite; }} .card.break .card-orbit::after {{ background: var(--slate); box-shadow: 0 0 8px var(--slate); }}
+.card-asset {{ font-family: 'Bebas Neue', sans-serif; font-size: 42px; letter-spacing: 0.05em; margin-bottom: 8px; }}
+.card-signal {{ font-family: 'Space Mono', monospace; font-size: 12px; letter-spacing: 0.2em; text-transform: uppercase; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }}
+.card.hold .card-signal {{ color: var(--gold); }} .card.buy .card-signal {{ color: var(--green); }} .card.sell .card-signal {{ color: var(--red); }} .card.break .card-signal {{ color: var(--slate); }}
+.signal-dot {{ width: 7px; height: 7px; border-radius: 50%; }}
+.card-meta {{ display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }}
+.meta-pill {{ font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 0.15em; text-transform: uppercase; color: rgba(255,255,255,0.35); border: 1px solid rgba(255,255,255,0.1); padding: 3px 8px; border-radius: 4px; }}
+.entry-date {{ font-family: 'Space Mono', monospace; font-size: 10px; color: rgba(255,255,255,0.3); letter-spacing: 0.05em; }}
+.entry-date strong {{ color: rgba(255,255,255,0.55); font-weight: 400; }}
+.card-glyph {{ font-family: 'Bebas Neue', sans-serif; font-size: 72px; opacity: 0.1; }}
+footer {{ margin-top: 60px; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.07); display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; }}
+.footer-logo {{ font-family: 'Bebas Neue', sans-serif; font-size: 18px; letter-spacing: 0.15em; color: rgba(255,255,255,0.3); }}
+.footer-text {{ font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255,255,255,0.2); text-align: right; line-height: 1.8; }}
+</style>
+</head>
+<body>
+<canvas id="space"></canvas>
+<div class="wrap">
+  <div class="hero">
+    <div class="eyebrow"><span class="eyebrow-dot"></span>Market Intelligence Active<span class="eyebrow-dot"></span></div>
+    <h1>TANK<span>RICH</span><br>SIGNALS</h1>
+    <div class="timestamp">↻ UPDATED <em>{html.escape(timestamp)}</em></div>
+  </div>
+  <div class="solar-divider">
+    <div class="div-line"></div>
+    <div class="orbit-container">
+      <div class="sun"></div><div class="orbit orbit-1"><div class="planet"></div></div><div class="orbit orbit-2"><div class="planet"></div></div><div class="orbit orbit-3"><div class="planet"></div></div>
+    </div>
+    <div class="div-line"></div>
+  </div>
+  <div class="cards">
+    <section class="signals-explainer">
+      <h2>New to Tankrich Signals?</h2>
+      <p>If you're wondering what each signal means and how to interpret these updates, start with the full methodology and explanation shared by Vivek Bothra.</p>
+      <a href="https://open.substack.com/pub/vivekbothra/p/tankrich-signals?" target="_blank" rel="noopener noreferrer">Read signal explanation ↗</a>
+    </section>
+{cards_html}
+  </div>
+  <footer>
+    <div class="footer-logo">TANKRICH</div>
+    <div class="footer-text">Signals auto-generated every Monday 09:00 UTC<br>Data: Kraken/Coinbase (BTC) · Yahoo Finance ETFs (GLD/SLV)</div>
+  </footer>
+</div>
+<script>
+const canvas=document.getElementById('space'),ctx=canvas.getContext('2d');let W,H,stars=[],shooters=[];function resize(){{W=canvas.width=window.innerWidth;H=canvas.height=window.innerHeight}}resize();window.addEventListener('resize',()=>{{resize();initStars()}});function rand(a,b){{return a+Math.random()*(b-a)}}function initStars(){{stars=[];const count=Math.floor(W*H/3500);for(let i=0;i<count;i++)stars.push({{x:rand(0,W),y:rand(0,H),r:rand(.3,1.8),alpha:rand(.2,1),speed:rand(.0002,.001),phase:rand(0,Math.PI*2)}})}}initStars();class Shooter{{constructor(){{this.reset()}}reset(){{this.x=rand(0,W*.7);this.y=rand(0,H*.4);this.speed=rand(8,16);this.life=1;this.decay=rand(.012,.025);this.angle=rand(Math.PI/8,Math.PI/4);this.vx=Math.cos(this.angle)*this.speed;this.vy=Math.sin(this.angle)*this.speed}}draw(){{ctx.save();ctx.globalAlpha=.9*this.life;const grad=ctx.createLinearGradient(this.x,this.y,this.x-8*this.vx,this.y-8*this.vy);grad.addColorStop(0,'rgba(255,255,255,0.9)');grad.addColorStop(1,'rgba(255,255,255,0)');ctx.strokeStyle=grad;ctx.lineWidth=1.5;ctx.beginPath();ctx.moveTo(this.x,this.y);ctx.lineTo(this.x-8*this.vx,this.y-8*this.vy);ctx.stroke();ctx.restore()}}update(){{return this.x+=this.vx,this.y+=this.vy,this.life-=this.decay,this.life>0}}}}function drawNebulae(){{[{{x:.15*W,y:.25*H,r:220,c:'80,40,160'}},{{x:.82*W,y:.15*H,r:180,c:'0,80,160'}},{{x:.5*W,y:.8*H,r:250,c:'0,120,80'}},{{x:.9*W,y:.7*H,r:160,c:'140,60,20'}}].forEach(n=>{{const g=ctx.createRadialGradient(n.x,n.y,0,n.x,n.y,n.r);g.addColorStop(0,`rgba(${{n.c}},0.06)`);g.addColorStop(.5,`rgba(${{n.c}},0.02)`);g.addColorStop(1,'rgba(0,0,0,0)');ctx.beginPath();ctx.arc(n.x,n.y,n.r,0,2*Math.PI);ctx.fillStyle=g;ctx.fill()}})}}let lastShooter=0;function loop(ts){{const t=.001*ts;ctx.clearRect(0,0,W,H);const bg=ctx.createRadialGradient(W/2,H/2,0,W/2,H/2,Math.max(W,H));bg.addColorStop(0,'#0a0e18');bg.addColorStop(1,'#000004');ctx.fillStyle=bg;ctx.fillRect(0,0,W,H);drawNebulae();stars.forEach(s=>{{const a=s.alpha*(.6+.4*Math.sin(1e3*t*s.speed+s.phase));ctx.beginPath();ctx.arc(s.x,s.y,s.r,0,2*Math.PI);ctx.fillStyle=`rgba(255,255,255,${{a}})`;ctx.fill()}});if(ts-lastShooter>rand(1800,4000)){{shooters.push(new Shooter);lastShooter=ts}}shooters=shooters.filter(s=>(s.draw(),s.update()));requestAnimationFrame(loop)}}requestAnimationFrame(loop);
+</script>
+</body>
+</html>
+'''
+
+
+def main() -> int:
+    content = INDEX_PATH.read_text(encoding="utf-8")
+
+    if 'id="space"' in content and 'class="signals-explainer"' in content:
+        print("Themed layout already present; no changes needed.")
+        return 0
+
+    parsed = _extract_basic_layout_data(content)
+    if not parsed:
+        print("No known basic layout signature found; leaving index.html unchanged.")
+        return 0
+
+    updated, cards = parsed
+    themed = _build_themed_page(updated=updated, cards=cards)
+    INDEX_PATH.write_text(themed, encoding="utf-8")
+    print(f"Restored themed layout with {len(cards)} signal cards.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- The site deploy replaced the styled "galaxy" layout with a simplified fallback `index.html` and removed the recovery tooling, leaving the UI vulnerable to regressions.
- Restore the themed UI while providing an automated guard so future signal deploys can't permanently remove the styled layout or lose the displayed signal data.

### Description
- Restored the styled (galaxy) frontpage by updating `index.html` to the themed layout while preserving the current signals and timestamp.
- Reintroduced the recovery script `scripts/theme_guard.py` that detects the plain fallback HTML, extracts signal cards/timestamp, and rebuilds the themed page from that data.
- Added the GitHub Action workflow `.github/workflows/theme-guard.yml` that runs the recovery script on a Monday schedule, manual dispatch, and on pushes to `main`, and it only auto-commits fixes when appropriate to avoid recursion.
- The workflow includes a guard condition (`if: github.event_name != 'push' || github.actor != 'github-actions[bot]'`) to avoid self-triggered commit loops.

### Testing
- Ran `python scripts/theme_guard.py` and observed it restore the themed layout when a basic layout was present and report "Themed layout already present" when up-to-date; this succeeded.
- Compiled the script with `python -m py_compile scripts/theme_guard.py` which succeeded with no syntax errors.
- Launched a local `python -m http.server 4173` and captured a full-page screenshot via an automated Playwright script to validate the restored UI rendering; the screenshot run succeeded and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6627f2eb4832fbe14c42daf364f60)